### PR TITLE
Update mdd-data to fix issues with the ciscops.mdd.nso_update_netbox playbook

### DIFF
--- a/mdd-data/org/oc-site-routers.yml
+++ b/mdd-data/org/oc-site-routers.yml
@@ -158,7 +158,7 @@ mdd_data:
           openconfig-network-instance:enabled-address-families:
             - IPV4
             - IPV6
-          openconfig-network-instance:route-distinguisher: '1:3'
+          openconfig-network-instance:route-distinguisher: '1:1'
         openconfig-network-instance:inter-instance-policies:
           openconfig-network-instance:apply-policy:
             openconfig-network-instance:config:

--- a/mdd-data/org/oc-vlan.yml
+++ b/mdd-data/org/oc-vlan.yml
@@ -16,6 +16,11 @@ mdd_data:
                 openconfig-network-instance:vlan-id: 10
                 openconfig-network-instance:name: 'Internal-1'
                 openconfig-network-instance:status: 'ACTIVE'
+            - openconfig-network-instance:vlan-id: 99
+              openconfig-network-instance:config:
+                openconfig-network-instance:vlan-id: 99
+                openconfig-network-instance:name: 'Native'
+                openconfig-network-instance:status: 'ACTIVE'
             - openconfig-network-instance:vlan-id: 100
               openconfig-network-instance:config:
                 openconfig-network-instance:vlan-id: 100

--- a/mdd-data/org/region1/hq/hq-rtr2/hq-rtr2.cfg
+++ b/mdd-data/org/region1/hq/hq-rtr2/hq-rtr2.cfg
@@ -21,7 +21,7 @@ vrf definition Mgmt-intf
  exit-address-family
 !
 vrf definition internal_1
- rd 1:2
+ rd 1:1
  route-target export 1:1
  route-target import 1:1
  !

--- a/mdd-data/org/region1/hq/hq-rtr2/oc-routing.yml
+++ b/mdd-data/org/region1/hq/hq-rtr2/oc-routing.yml
@@ -19,7 +19,7 @@ mdd_data:
                     openconfig-network-instance:router-id: 10.255.255.12
       - openconfig-network-instance:name: internal_1
         openconfig-network-instance:config:
-          openconfig-network-instance:route-distinguisher: '1:2'
+          openconfig-network-instance:route-distinguisher: '1:1'
       - openconfig-network-instance:name: Mgmt-intf
         openconfig-network-instance:config:
           openconfig-network-instance:name: Mgmt-intf


### PR DESCRIPTION
Fixes to mdd-data required in order for the ciscops.mdd.nso_update_netbox playbook to function properly:

- Set the RD to 1:1 for all instances of VRF internal_1.  Previously each site had it's one RD for internal_1.  The nso_update_playbook would then create four different VRFs in NetBox instead of just one.
- Set a name for VLAN 99.  With a name set for a VLAN, the playbook does not properly configure VLANs on trunks in NetBox.